### PR TITLE
Responds to selector when services has Implement delegate method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+.DS_Store

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -19,9 +19,11 @@ class AppDelegate: PluggableApplicationDelegate {
             LoggerApplicationService()
         ]
     }
+}
 
-    override init() {
-        super.init()
+extension AppDelegate {
+    override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         self.window = UIWindow(frame: UIScreen.main.bounds)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 }

--- a/Sources/AppServicesManager+UNUserNotification.swift
+++ b/Sources/AppServicesManager+UNUserNotification.swift
@@ -13,16 +13,30 @@ extension PluggableApplicationDelegate: UNUserNotificationCenterDelegate {
 
     @available(iOS 10.0, *)
     public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        for service in _services {
-            service.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
-        }
+        apply({ (service, completion) -> Void? in
+            service.userNotificationCenter?(
+                center,
+                willPresent: notification,
+                withCompletionHandler: { opt in
+                    completion(opt)
+            })
+        }, completionHandler: { options in
+            completionHandler(UNNotificationPresentationOptions(options))
+        })
     }
 
     @available(iOS 10.0, *)
     public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        for service in _services {
-            service.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
-        }
+        apply({ (service, completion) -> Void? in
+            service.userNotificationCenter?(
+                center,
+                didReceive: response,
+                withCompletionHandler: {
+                    completion(())
+            })
+        }, completionHandler: { _ in
+            completionHandler()
+        })
     }
 
 


### PR DESCRIPTION
Fix UserNotifications delegate methods implementation.
Override "responds(to:)". resolve some warning, such as: 
"You've implemented -[<UIApplicationDelegate> application:performFetchWithCompletionHandler:], but you still need to add "fetch" to the list of your supported UIBackgroundModes in your Info.plist.
You've implemented -[<UIApplicationDelegate> application:didReceiveRemoteNotification:fetchCompletionHandler:], but you still need to add "remote-notification" to the list of your supported UIBackgroundModes in your Info.plist.