### PR TITLE
Update access controls

### DIFF
--- a/Sources/AppServicesManager+UNUserNotification.swift
+++ b/Sources/AppServicesManager+UNUserNotification.swift
@@ -12,14 +12,14 @@ import UserNotifications
 extension PluggableApplicationDelegate: UNUserNotificationCenterDelegate {
 
     @available(iOS 10.0, *)
-    public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    open func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         for service in _services {
             service.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
         }
     }
 
     @available(iOS 10.0, *)
-    public func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    open func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         for service in _services {
             service.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
         }
@@ -27,7 +27,7 @@ extension PluggableApplicationDelegate: UNUserNotificationCenterDelegate {
 
 
     @available(iOS 12.0, *)
-    public func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
+    open func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
         for service in _services {
             service.userNotificationCenter?(center, openSettingsFor: notification)
         }


### PR DESCRIPTION
UserNotification delegate methods access controls changes from public to open, so classes out of the module can override them.